### PR TITLE
Foreman 1.7 changed the name of the port variable from port to http_port...

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -482,6 +482,8 @@ class foreman (
   $proxy_ssl_ca             = params_lookup( 'proxy_ssl_ca' ),
   $proxy_ssl_cert           = params_lookup( 'proxy_ssl_cert' ),
   $proxy_ssl_key            = params_lookup( 'proxy_ssl_key' ),
+  $proxy_listen_name        = params_lookup( 'proxy_listen_name' ),
+  $proxy_listen_port        = params_lookup( 'proxy_listen_port' ),
   $proxy_user               = params_lookup( 'proxy_user' ),
   $proxy_group              = params_lookup( 'proxy_group' )
   ) inherits foreman::params {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -88,11 +88,13 @@ class foreman::params {
   $service_user     = 'foreman'
   $service_group    = 'foreman'
 
-  $proxy_data_dir = '/var/lib/foreman-proxy'
-  $proxy_ssl_dir  = "${proxy_data_dir}/ssl"
-  $proxy_ssl_ca   = "${proxy_ssl_dir}/ca.pem"
-  $proxy_ssl_cert = "${proxy_ssl_dir}/${::fqdn}.pem"
-  $proxy_ssl_key  = "${proxy_ssl_dir}/${::fqdn}.key.pem"
+  $proxy_data_dir    = '/var/lib/foreman-proxy'
+  $proxy_ssl_dir     = "${proxy_data_dir}/ssl"
+  $proxy_ssl_ca      = "${proxy_ssl_dir}/ca.pem"
+  $proxy_ssl_cert    = "${proxy_ssl_dir}/${::fqdn}.pem"
+  $proxy_ssl_key     = "${proxy_ssl_dir}/${::fqdn}.key.pem"
+  $proxy_listen_port = '8443'
+  $proxy_listen_name = 'port'
 
   $proxy_user     = 'foreman-proxy'
   $proxy_group    = 'foreman-proxy'

--- a/templates/proxy-settings.yml.erb
+++ b/templates/proxy-settings.yml.erb
@@ -19,7 +19,7 @@
 :daemon_pid: /var/run/foreman-proxy/foreman-proxy.pid
 
 # port used by the proxy
-:port: 8443
+:<%= scope.lookupvar('foreman::proxy_listen_name') %>: <%= scope.lookupvar('foreman::proxy_listen_port') %>
 
 # Enable TFTP management
 :tftp: <%= scope.lookupvar('foreman::bool_proxy_feature_tftp') %>


### PR DESCRIPTION
... or https_port, I've changed the params and template to adjust to this  change, by default nothing change and the old name is used, but now it's possible to use the appropriate variable to change the name of the listen variable and also the port.